### PR TITLE
Fix some opcodes

### DIFF
--- a/PADAUK_FPPA_14_bit_instruction_set.wikitext
+++ b/PADAUK_FPPA_14_bit_instruction_set.wikitext
@@ -100,9 +100,9 @@ These devices feature a 14-bit wide code memory. Byte order is little endian.
 
 !        ||0||0||colspan="5"|''opcode''|| colspan="7"|''7-bit MEM addr''||colspan="6"| 16 bit memory operations
 |-
-| 0x03.. ||0||0||0||0||1||1||0||colspan="6"|''M''||0||align="left"| STT16 M   ||  ||  ||  ||  ||align="left"| M ← Timer16 (last bit of M set to 1, M must be word aligned)
+| 0x03.. ||0||0||0||0||1||1||0||colspan="6"|''M''||0||align="left"| STT16 M   ||  ||  ||  ||  ||align="left"| M ← Timer16 (last bit of M set to 0, M must be word aligned)
 |-
-| 0x03.. ||0||0||0||0||1||1||0||colspan="6"|''M''||1||align="left"| LDT16 M   ||  ||  ||  ||  ||align="left"| Timer16 ← M (last bit of M set to 0, M must be word aligned)
+| 0x03.. ||0||0||0||0||1||1||0||colspan="6"|''M''||1||align="left"| LDT16 M   ||  ||  ||  ||  ||align="left"| Timer16 ← M (last bit of M set to 1, M must be word aligned)
 |-
 | 0x03.. ||0||0||0||0||1||1||1||colspan="6"|''M''||0||align="left"| IDXM M, A ||  ||  ||  ||  ||align="left"| [M] ← A (last bit of M set to 0, M must be word aligned, 2 cycles)
 |-

--- a/PADAUK_FPPA_14_bit_instruction_set.wikitext
+++ b/PADAUK_FPPA_14_bit_instruction_set.wikitext
@@ -142,7 +142,7 @@ These devices feature a 14-bit wide code memory. Byte order is little endian.
 |-
 | 0x0B.. ||0||0||1||0||1||1||0||colspan="7"|''M''||align="left"| XOR M, A   ||ZF||  ||  ||  ||align="left"| M ← M ^ A
 |-
-| 0x0B.. ||0||0||1||0||1||1||0||colspan="7"|''M''||align="left"| MOV M, A   ||ZF||  ||  ||  ||align="left"| M ← A
+| 0x0B.. ||0||0||1||0||1||1||1||colspan="7"|''M''||align="left"| MOV M, A   ||ZF||  ||  ||  ||align="left"| M ← A
 |-
 | 0x0C.. ||0||0||1||1||0||0||0||colspan="7"|''M''||align="left"| ADD A, M   ||ZF||CF||AC||OV||align="left"| A ← A + M
 |-

--- a/PADAUK_FPPA_14_bit_instruction_set.wikitext
+++ b/PADAUK_FPPA_14_bit_instruction_set.wikitext
@@ -100,9 +100,9 @@ These devices feature a 14-bit wide code memory. Byte order is little endian.
 
 !        ||0||0||colspan="5"|''opcode''|| colspan="7"|''7-bit MEM addr''||colspan="6"| 16 bit memory operations
 |-
-| 0x03.. ||0||0||0||0||1||1||0||colspan="6"|''M''||0||align="left"| LDT16 M   ||  ||  ||  ||  ||align="left"| Timer16 ← M (last bit of M set to 0, M must be word aligned)
+| 0x03.. ||0||0||0||0||1||1||0||colspan="6"|''M''||0||align="left"| STT16 M   ||  ||  ||  ||  ||align="left"| M ← Timer16 (last bit of M set to 1, M must be word aligned)
 |-
-| 0x03.. ||0||0||0||0||1||1||0||colspan="6"|''M''||1||align="left"| STT16 M   ||  ||  ||  ||  ||align="left"| M ← Timer16 (last bit of M set to 1, M must be word aligned)
+| 0x03.. ||0||0||0||0||1||1||0||colspan="6"|''M''||1||align="left"| LDT16 M   ||  ||  ||  ||  ||align="left"| Timer16 ← M (last bit of M set to 0, M must be word aligned)
 |-
 | 0x03.. ||0||0||0||0||1||1||1||colspan="6"|''M''||0||align="left"| IDXM M, A ||  ||  ||  ||  ||align="left"| [M] ← A (last bit of M set to 0, M must be word aligned, 2 cycles)
 |-


### PR DESCRIPTION
While writing a disassembler I noticed some opcodes are documented wrongly (the disassembled code didn't match). Upon investigation it seems they are actually wrong in the documentation, does this match for anyone else?

There might be more I'll discover while continuing the work.