### PR TITLE
Document byte order for push af / pop af

### DIFF
--- a/PADAUK_FPPA_13_bit_instruction_set.wikitext
+++ b/PADAUK_FPPA_13_bit_instruction_set.wikitext
@@ -55,9 +55,9 @@ These devices feature a 13-bit wide code memory. Byte order is little endian. Th
 |-
 | 0x0031 ||0||0||0||0||0||0||0||1||1||0||0||0||1||colspan="6"| ''?''
 |-
-| 0x0032 ||0||0||0||0||0||0||0||1||1||0||0||1||0||align="left"| PUSHAF  ||  ||  ||  ||  ||align="left"| Push A and flags to stack
+| 0x0032 ||0||0||0||0||0||0||0||1||1||0||0||1||0||align="left"| PUSHAF  ||  ||  ||  ||  ||align="left"| Push A and flags to stack: [SP] ← A, [SP + 1] ← F, SP ← SP + 2
 |-
-| 0x0033 ||0||0||0||0||0||0||0||1||1||0||0||1||1||align="left"| POPAF   ||ZF||CF||AC||OV||align="left"| Pop A and flags from stack
+| 0x0033 ||0||0||0||0||0||0||0||1||1||0||0||1||1||align="left"| POPAF   ||ZF||CF||AC||OV||align="left"| Pop A and flags from stack: SP ← SP + 2, F ← [SP + 1], [SP] ← A
 |-
 | 0x0034 ||0||0||0||0||0||0||0||1||1||0||1||0||0||colspan="6"| ''?''
 |-

--- a/PADAUK_FPPA_13_bit_instruction_set.wikitext
+++ b/PADAUK_FPPA_13_bit_instruction_set.wikitext
@@ -1,5 +1,5 @@
 ==PADAUK FPPA core devices (13 bit)==
-These devices feature a 13-bit wide code memory. Byte order is little endian.
+These devices feature a 13-bit wide code memory. Byte order is little endian. The instruction set is called SYM_84B in Padauk include files. The SDCC backend will be called pdk13.
 
 {|class="wikitable" style="text-align:center"
 |+ 13-bit FPPA instruction set
@@ -250,3 +250,7 @@ These devices feature a 13-bit wide code memory. Byte order is little endian.
 
 
 |}
+
+There seem to be no optional instructions in this instruction set, there is no known implementation that supports MUL.
+
+

--- a/PADAUK_FPPA_14_bit_instruction_set.wikitext
+++ b/PADAUK_FPPA_14_bit_instruction_set.wikitext
@@ -53,9 +53,9 @@ These devices feature a 14-bit wide code memory. Byte order is little endian. Th
 |-
 | 0x0071 ||0||0||0||0||0||0||0||1||1||1||0||0||0||1||colspan="6"| ''?''
 |-
-| 0x0072 ||0||0||0||0||0||0||0||1||1||1||0||0||1||0||align="left"| PUSHAF  ||  ||  ||  ||  ||align="left"| Push A and flags to stack
+| 0x0072 ||0||0||0||0||0||0||0||1||1||1||0||0||1||0||align="left"| PUSHAF  ||  ||  ||  ||  ||align="left"| Push A and flags to stack: [SP] ← A, [SP + 1] ← F, SP ← SP + 2
 |-
-| 0x0073 ||0||0||0||0||0||0||0||1||1||1||0||0||1||1||align="left"| POPAF   ||ZF||CF||AC||OV||align="left"| Pop A and flags from stack
+| 0x0073 ||0||0||0||0||0||0||0||1||1||1||0||0||1||1||align="left"| POPAF   ||ZF||CF||AC||OV||align="left"| Pop A and flags from stack: SP ← SP + 2, F ← [SP + 1], [SP] ← A
 |-
 | 0x0074 ||0||0||0||0||0||0||0||1||1||1||0||1||0||0||colspan="6"| ''?''
 |-

--- a/PADAUK_FPPA_14_bit_instruction_set.wikitext
+++ b/PADAUK_FPPA_14_bit_instruction_set.wikitext
@@ -1,5 +1,5 @@
 ==PADAUK FPPA core devices (14 bit)==
-These devices feature a 14-bit wide code memory. Byte order is little endian.
+These devices feature a 14-bit wide code memory. Byte order is little endian. The instruction set is called SYM_85A in Padauk include files. The SDCC backend is called pdk14.
 
 {|class="wikitable" style="text-align:center"
 |+ 14-bit FPPA instruction set
@@ -86,7 +86,7 @@ These devices feature a 14-bit wide code memory. Byte order is little endian.
 
 !        ||0||0||0||0||0||colspan="3"|''c''|| colspan="6"|''6-bit IO addr''||colspan="6"| Operations with A and IO
 |-
-| 0x00C.<br/>0x00D.<br/>0x00E.<br/>0x00F. ||0||0||0||0||0||0||1||1||colspan="6"|''IO''||align="left"| XOR IO, A ||  ||  ||  ||  ||align="left"| IO ← IO ^ A
+| 0x00C.<br/>0x00D.<br/>0x00E.<br/>0x00F. ||0||0||0||0||0||0||1||1||colspan="6"|''IO''||align="left"| XOR IO, A ||  ||  ||  ||  ||align="left"| IO ← IO ^ A (if available)
 |-
 | 0x01.. ||0||0||0||0||0||1||1||0||colspan="6"|''IO''||align="left"| MOV IO, A ||  ||  ||  ||  ||align="left"| IO ← A
 |-
@@ -124,13 +124,13 @@ These devices feature a 14-bit wide code memory. Byte order is little endian.
 
 !        ||0||0||colspan="5"|''opcode''|| colspan="7"|''7-bit MEM addr''||colspan="6"| Operations with A and memory
 |-
-| 0x06.. ||0||0||0||1||1||0||0||colspan="7"|''M''||align="left"| COMP A, M  ||ZF||CF||AC||OV||align="left"| Compare A with M (flags changed according to (A-M))
+| 0x06.. ||0||0||0||1||1||0||0||colspan="7"|''M''||align="left"| COMP A, M  ||ZF||CF||AC||OV||align="left"| Compare A with M (flags changed according to (A-M)) (if available)
 |-
-| 0x06.. ||0||0||0||1||1||0||1||colspan="7"|''M''||align="left"| COMP M, A  ||ZF||CF||AC||OV||align="left"| Compare M with A (flags changed according to (M-A))
+| 0x06.. ||0||0||0||1||1||0||1||colspan="7"|''M''||align="left"| COMP M, A  ||ZF||CF||AC||OV||align="left"| Compare M with A (flags changed according to (M-A)) (if available)
 |-
-| 0x07.. ||0||0||0||1||1||1||0||colspan="7"|''M''||align="left"| NADD A, M  ||ZF||CF||AC||OV||align="left"| A ← M + NEG(A)
+| 0x07.. ||0||0||0||1||1||1||0||colspan="7"|''M''||align="left"| NADD A, M  ||ZF||CF||AC||OV||align="left"| A ← M + NEG(A) (if available)
 |-
-| 0x07.. ||0||0||0||1||1||1||1||colspan="7"|''M''||align="left"| NADD M, A  ||ZF||CF||AC||OV||align="left"| M ← NEG(M) + A
+| 0x07.. ||0||0||0||1||1||1||1||colspan="7"|''M''||align="left"| NADD M, A  ||ZF||CF||AC||OV||align="left"| M ← NEG(M) + A (if available)
 |-
 | 0x08.. ||0||0||1||0||0||0||0||colspan="7"|''M''||align="left"| ADD M, A   ||ZF||CF||AC||OV||align="left"| M ← M + A
 |-
@@ -263,3 +263,21 @@ These devices feature a 14-bit wide code memory. Byte order is little endian.
 
 
 |}
+
+
+{|class="wikitable" style="text-align:center"
+|+ Instruction support by device
+! Device || COMP A, M || COMP M, A || MUL || NADD A, M || NADD M, A || XOR IO, A
+|-
+| PFS154  || - || - || - || - || - || Y
+| PMC131  || Y || Y || Y || Y || Y || -
+| PMS130  || Y || Y || Y || Y || Y || -
+| PMS131  || Y || Y || Y || Y || Y || -
+| PMS132  || Y || Y || Y || Y || Y || Y
+| PMS152  || Y || Y || - || Y || Y || Y
+| PMS154B || Y || Y || - || Y || Y || Y
+| PMS154C || Y || Y || - || Y || Y || Y
+| PMS171B || - || - || - || - || - || Y
+|-
+|}
+

--- a/PADAUK_FPPA_14_bit_instruction_set.wikitext
+++ b/PADAUK_FPPA_14_bit_instruction_set.wikitext
@@ -274,6 +274,7 @@ These devices feature a 14-bit wide code memory. Byte order is little endian. Th
 | PMS130  || Y || Y || Y || Y || Y || -
 | PMS131  || Y || Y || Y || Y || Y || -
 | PMS132  || Y || Y || Y || Y || Y || Y
+| PMS132B || Y || Y || Y || Y || Y || Y
 | PMS152  || Y || Y || - || Y || Y || Y
 | PMS154B || Y || Y || - || Y || Y || Y
 | PMS154C || Y || Y || - || Y || Y || Y

--- a/PADAUK_FPPA_15_bit_instruction_set.wikitext
+++ b/PADAUK_FPPA_15_bit_instruction_set.wikitext
@@ -53,9 +53,9 @@ These devices feature a 15-bit wide code memory. Byte order is little endian. Th
 |-             
 | 0x0071 ||0||0||0||0||0||0||0||0||1||1||1||0||0||0||1||colspan="6"| ''?''
 |-             
-| 0x0072 ||0||0||0||0||0||0||0||0||1||1||1||0||0||1||0||align="left"| PUSHAF  ||  ||  ||  ||  ||align="left"| Push A and flags to stack
+| 0x0072 ||0||0||0||0||0||0||0||0||1||1||1||0||0||1||0||align="left"| PUSHAF  ||  ||  ||  ||  ||align="left"| Push A and flags to stack: [SP] ← A, [SP + 1] ← F, SP ← SP + 2
 |-             
-| 0x0073 ||0||0||0||0||0||0||0||0||1||1||1||0||0||1||1||align="left"| POPAF   ||ZF||CF||AC||OV||align="left"| Pop A and flags from stack
+| 0x0073 ||0||0||0||0||0||0||0||0||1||1||1||0||0||1||1||align="left"| POPAF   ||ZF||CF||AC||OV||align="left"| Pop A and flags from stack: SP ← SP + 2, F ← [SP + 1], [SP] ← A
 |-             
 | 0x0074 ||0||0||0||0||0||0||0||0||1||1||1||0||1||0||0||colspan="6"| ''?''
 |-             

--- a/PADAUK_FPPA_15_bit_instruction_set.wikitext
+++ b/PADAUK_FPPA_15_bit_instruction_set.wikitext
@@ -1,7 +1,5 @@
-
-
 ==PADAUK FPPA core devices (15 bit)==
-These devices feature a 15-bit wide code memory. Byte order is little endian.
+These devices feature a 15-bit wide code memory. Byte order is little endian. The instruction set is called SYM_86B in Padauk include files. The SDCC backend will be called pdk15.
 
 {|class="wikitable" style="text-align:center"
 |+ 15-bit FPPA instruction set
@@ -270,3 +268,14 @@ These devices feature a 15-bit wide code memory. Byte order is little endian.
 
 
 |}
+
+{|class="wikitable" style="text-align:center"
+|+ Instruction support by device
+! Device || MUL || NMOV A, M || NMOV M, A || SWAP M || XOR A, IO
+|-
+| PFS173  || - || - || - || - || -
+| PMC133  || Y || Y || Y || Y || Y
+| PMS134  || Y || Y || Y || Y || Y
+|-
+|}
+

--- a/PADAUK_FPPA_16_bit_instruction_set.wikitext
+++ b/PADAUK_FPPA_16_bit_instruction_set.wikitext
@@ -1,5 +1,5 @@
 ==PADAUK FPPA core devices (16 bit)==
-These devices feature a 16-bit wide code memory. Byte order is little endian.
+These devices feature a 16-bit wide code memory. Byte order is little endian. The instruction set is called SYM_83A in Padauk include files. The SDCC backend will be called pdk16.
 
 {|class="wikitable" style="text-align:center"
 |+ 16-bit FPPA instruction set
@@ -89,11 +89,11 @@ These devices feature a 16-bit wide code memory. Byte order is little endian.
 |-
 !    ||0||0||0||0||0||0||0||0||0||1||colspan="6"| ||colspan="6"|Miscellaneous instructions
 |-
-| 0x004.<br/>0x005. ||0||0||0||0||0||0||0||0||0||1||0||k||k||k||k||k||align="left"| PMODE k   ||  ||  ||  ||  ||align="left"| Set PMODE k
+| 0x004.<br/>0x005. ||0||0||0||0||0||0||0||0||0||1||0||k||k||k||k||k||align="left"| PMODE k   ||  ||  ||  ||  ||align="left"| Set PMODE k (if available)
 |-
-| 0x0060 ||0||0||0||0||0||0||0||0||0||1||1||0||n||n||n||n||align="left"| POPWPC n  ||  ||  ||  ||  ||align="left"| Pop word PC(core n) from stack
+| 0x0060 ||0||0||0||0||0||0||0||0||0||1||1||0||n||n||n||n||align="left"| POPWPC n  ||  ||  ||  ||  ||align="left"| Pop word PC(core n) from stack (if available)
 |-
-| 0x0070 ||0||0||0||0||0||0||0||0||0||1||1||1||n||n||n||n||align="left"| PUSHWPC n ||  ||  ||  ||  ||align="left"| Push word PC(core n) to stack
+| 0x0070 ||0||0||0||0||0||0||0||0||0||1||1||1||n||n||n||n||align="left"| PUSHWPC n ||  ||  ||  ||  ||align="left"| Push word PC(core n) to stack (if available)
 |-
 |colspan="23"|
 |-
@@ -113,9 +113,9 @@ These devices feature a 16-bit wide code memory. Byte order is little endian.
 |-
 | 0x02..<br/>0x03.. ||0||0||0||0||0||0||1||colspan="8"|''M''||1||align="left"| LDT16 M   ||  ||  ||  ||  ||align="left"| Timer16 ← M (last bit of M set to 1, M must be word aligned)
 |-
-| 0x04..<br/>0x05.. ||0||0||0||0||0||1||0||colspan="8"|''M''||0||align="left"| POPW M    ||  ||  ||  ||  ||align="left"| Pop word from stack to memory M (last bit of M set to 0, M must be word aligned)
+| 0x04..<br/>0x05.. ||0||0||0||0||0||1||0||colspan="8"|''M''||0||align="left"| POPW M    ||  ||  ||  ||  ||align="left"| Pop word from stack to memory M (last bit of M set to 0, M must be word aligned) (if available)
 |-
-| 0x05..<br/>0x05.. ||0||0||0||0||0||1||0||colspan="8"|''M''||1||align="left"| PUSHW M   ||  ||  ||  ||  ||align="left"| Push word from memory M to stack (last bit of M set to 1, M must be word aligned)
+| 0x05..<br/>0x05.. ||0||0||0||0||0||1||0||colspan="8"|''M''||1||align="left"| PUSHW M   ||  ||  ||  ||  ||align="left"| Push word from memory M to stack (last bit of M set to 1, M must be word aligned) (if available)
 |-
 | 0x06..<br/>0x07.. ||0||0||0||0||0||1||1||colspan="8"|''M''||0||align="left"| IGOTO M   ||  ||  ||  ||  ||align="left"| TODO (last bit of M set to 0, M must be word aligned)
 |-
@@ -314,3 +314,20 @@ These devices feature a 16-bit wide code memory. Byte order is little endian.
 |-
 
 |}
+
+{|class="wikitable" style="text-align:center"
+|+ Instruction support by device
+! Device || MUL || PMODE N || PUSHW pcN || PUSHW M || POPW M || POPW PCn
+|-
+| MCS11  || Y || Y || Y || Y || Y || Y
+| PMC232 || - || - || - || - || - || -
+| PMC234 || - || - || - || - || - || -
+| PMC251 || - || - || - || - || - || -
+| PMC271 || - || - || - || - || - || -
+| PMC884 || Y || Y || Y || Y || Y || Y
+| PMS232 || - || - || - || - || - || -
+| PMS234 || - || - || - || - || - || -
+| PMS271 || - || - || - || - || - || -
+|-
+|}
+

--- a/PADAUK_FPPA_16_bit_instruction_set.wikitext
+++ b/PADAUK_FPPA_16_bit_instruction_set.wikitext
@@ -57,9 +57,9 @@ These devices feature a 16-bit wide code memory. Byte order is little endian. Th
 |-                  
 | 0x0031 ||0||0||0||0||0||0||0||0||0||0||1||1||0||0||0||1||colspan="6"| ''?''
 |-                  
-| 0x0032 ||0||0||0||0||0||0||0||0||0||0||1||1||0||0||1||0||align="left"| PUSHAF  ||  ||  ||  ||  ||align="left"| Push A and flags to stack
+| 0x0032 ||0||0||0||0||0||0||0||0||0||0||1||1||0||0||1||0||align="left"| PUSHAF  ||  ||  ||  ||  ||align="left"| Push A and flags to stack: [SP] ← A, [SP + 1] ← F, SP ← SP + 2
 |-                  
-| 0x0033 ||0||0||0||0||0||0||0||0||0||0||1||1||0||0||1||1||align="left"| POPAF   ||ZF||CF||AC||OV||align="left"| Pop A and flags from stack
+| 0x0033 ||0||0||0||0||0||0||0||0||0||0||1||1||0||0||1||1||align="left"| POPAF   ||ZF||CF||AC||OV||align="left"| Pop A and flags from stack: SP ← SP + 2, F ← [SP + 1], [SP] ← A
 |-                  
 | 0x0034 ||0||0||0||0||0||0||0||0||0||0||1||1||0||1||0||0||colspan="6"| ''?''
 |-                  


### PR DESCRIPTION
Today, I received information from padauk regarding the byte order of the push af / pop af instructions. Since this is important information for programmers, compiler writers and developers of simulators it should be included in the wiki.

Philipp
